### PR TITLE
feat: 优化视频解析页页面布局，增强合集数较多时的体验

### DIFF
--- a/DownKyi/CustomAction/GridSplitterExtensions.cs
+++ b/DownKyi/CustomAction/GridSplitterExtensions.cs
@@ -1,0 +1,45 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Xaml.Interactivity;
+
+namespace DownKyi.CustomAction;
+
+public class GridSplitterExtensions
+{
+    public static readonly AttachedProperty<ResetGridSplitterBehavior> ResetGridBehaviorProperty =
+        AvaloniaProperty.RegisterAttached<GridSplitterExtensions, GridSplitter, ResetGridSplitterBehavior>(
+            "ResetGridBehavior", coerce: OnResetGridBehaviorChanged);
+
+    public static ResetGridSplitterBehavior GetResetGridBehavior(GridSplitter obj)
+    {
+        return obj.GetValue(ResetGridBehaviorProperty);
+    }
+
+    public static void SetResetGridBehavior(GridSplitter obj, ResetGridSplitterBehavior value)
+    {
+        obj.SetValue(ResetGridBehaviorProperty, value);
+    }
+
+    private static ResetGridSplitterBehavior OnResetGridBehaviorChanged(AvaloniaObject obj, ResetGridSplitterBehavior behavior)
+    {
+        if (obj is GridSplitter gridSplitter)
+        {
+            var oldBehavior = GetResetGridBehavior(gridSplitter);
+            
+            if (oldBehavior != null)
+            {
+                var behaviors = Interaction.GetBehaviors(gridSplitter);
+                behaviors.Remove(oldBehavior);
+            }
+            
+            if (behavior != null)
+            {
+                var behaviors = Interaction.GetBehaviors(gridSplitter);
+                behaviors.Add(behavior);
+            }
+        }
+
+        return behavior;
+    }
+}

--- a/DownKyi/CustomAction/ResetGridSplitterBehavior.cs
+++ b/DownKyi/CustomAction/ResetGridSplitterBehavior.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactivity;
+
+namespace DownKyi.CustomAction;
+public class ResetGridSplitterBehavior : Behavior<GridSplitter>
+{
+    private Dictionary<int, GridLength> _originalColumnWidths = new ();
+    private Dictionary<int, GridLength> _originalRowHeights = new ();
+    private Grid _parentGrid;
+  
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        var gridSplitter = AssociatedObject;
+        _parentGrid = gridSplitter.Parent as Grid;
+
+        if (_parentGrid != null)
+        {
+            for (int i = 0; i < _parentGrid.ColumnDefinitions.Count; i++)
+            {
+                _originalColumnWidths[i] = _parentGrid.ColumnDefinitions[i].Width;
+            }
+
+            for (int i = 0; i < _parentGrid.RowDefinitions.Count; i++)
+            {
+                _originalRowHeights[i] = _parentGrid.RowDefinitions[i].Height;
+            }
+        }
+     
+    }
+    
+    private void OnRefreshRequested(object sender, EventArgs e)
+    {
+        ResetGrid();
+    }
+    
+    public void ResetGrid()
+    {
+        if (_parentGrid != null)
+        {
+            foreach (var kvp in _originalColumnWidths)
+            {
+                _parentGrid.ColumnDefinitions[kvp.Key].Width = kvp.Value;
+            }
+
+            foreach (var kvp in _originalRowHeights)
+            {
+                _parentGrid.RowDefinitions[kvp.Key].Height = kvp.Value;
+            }
+        }
+    }
+
+    protected override void OnDetachedFromVisualTree()
+    {
+        base.OnDetachedFromVisualTree();
+        ResetGrid();
+    }
+
+    
+}

--- a/DownKyi/ViewModels/ViewVideoDetailViewModel.cs
+++ b/DownKyi/ViewModels/ViewVideoDetailViewModel.cs
@@ -10,6 +10,7 @@ using DownKyi.Core.BiliApi.BiliUtils;
 using DownKyi.Core.BiliApi.VideoStream;
 using DownKyi.Core.Logging;
 using DownKyi.Core.Settings;
+using DownKyi.CustomAction;
 using DownKyi.Events;
 using DownKyi.Images;
 using DownKyi.Services;
@@ -121,6 +122,9 @@ public class ViewVideoDetailViewModel : ViewModelBase
         set => SetProperty(ref _noDataVisibility, value);
     }
 
+
+    public ResetGridSplitterBehavior ResetGridBehavior { get; set; } = new();
+
     #endregion
 
     public ViewVideoDetailViewModel(IEventAggregator eventAggregator, IDialogService dialogService) : base(eventAggregator, dialogService)
@@ -186,6 +190,7 @@ public class ViewVideoDetailViewModel : ViewModelBase
 
 
     private DelegateCommand? _inputSearchCommand;
+    
 
     public DelegateCommand InputSearchCommand => _inputSearchCommand ??= new DelegateCommand(ExecuteInputSearchCommand);
 
@@ -351,7 +356,7 @@ public class ViewVideoDetailViewModel : ViewModelBase
         }
 
         var section = VideoSections.FirstOrDefault(item => item.IsSelected);
-
+       
         if (section == null)
         {
             return;
@@ -391,7 +396,7 @@ public class ViewVideoDetailViewModel : ViewModelBase
 
     // 解析视频流事件
     private DelegateCommand<object>? _parseCommand;
-
+    
     public DelegateCommand<object> ParseCommand => _parseCommand ??= new DelegateCommand<object>(ExecuteParseCommand, CanExecuteParseCommand);
 
     /// <summary>
@@ -583,14 +588,15 @@ public class ViewVideoDetailViewModel : ViewModelBase
     private void InitView()
     {
         LogManager.Debug(Tag, "初始化页面元素");
-
+        ResetGridBehavior.ResetGrid();
         LoadingVisibility = true;
         ContentVisibility = false;
         NoDataVisibility = false;
-
         VideoSections.Clear();
         CaCheVideoSections.Clear();
     }
+    
+   
 
     /// <summary>
     /// 更新页面的统一方法

--- a/DownKyi/Views/ViewVideoDetail.axaml
+++ b/DownKyi/Views/ViewVideoDetail.axaml
@@ -252,40 +252,44 @@
                 </Grid>
             </DockPanel>
 
-            <Grid Grid.Row="1" Margin="10,10,10,10" RowDefinitions="auto,*,40">
-                <ListBox
-                    x:Name="NameVideoSections"
-                    Grid.Row="0"
-                    ItemContainerTheme="{StaticResource TagItemStyle}"
-                    ItemsSource="{Binding VideoSections, Mode=TwoWay}"
-                    Theme="{StaticResource TagStyle}"
-                    SelectionMode="Single">
-                    <ListBox.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <WrapPanel Orientation="Horizontal" />
-                        </ItemsPanelTemplate>
-                    </ListBox.ItemsPanel>
-                    <i:Interaction.Behaviors>
-                        <ia:EventTriggerBehavior EventName="SelectionChanged">
-                            <ia:InvokeCommandAction Command="{Binding VideoSectionsCommand}"
-                                                    CommandParameter="{Binding ElementName=NameVideoSections,Path=SelectedItem}" />
-                        </ia:EventTriggerBehavior>
-                        <ia:DataTriggerBehavior Binding="{Binding VideoSections.Count}" Value="0">
-                            <ia:ChangePropertyAction PropertyName="Height" Value="0" />
-                        </ia:DataTriggerBehavior>
-                        <ia:DataTriggerBehavior Binding="{Binding VideoSections.Count}" Value="1">
-                            <ia:ChangePropertyAction PropertyName="Height" Value="0" />
-                        </ia:DataTriggerBehavior>
-                        <ia:DataTriggerBehavior Binding="{Binding VideoSections.Count}"
-                                                ComparisonCondition="GreaterThan" Value="1">
-                            <ia:ChangePropertyAction PropertyName="Height" Value="Nan" />
-                        </ia:DataTriggerBehavior>
-                    </i:Interaction.Behaviors>
-                </ListBox>
-
+            <Grid Grid.Row="1" Margin="10,10,10,10" RowDefinitions="200,4,*,40">
+               <ScrollViewer MinHeight="200">
+                   <ListBox
+                   
+                       x:Name="NameVideoSections"
+                       Grid.Row="0"
+                       ItemContainerTheme="{StaticResource TagItemStyle}"
+                       ItemsSource="{Binding VideoSections, Mode=TwoWay}"
+                       Theme="{StaticResource TagStyle}"
+                       SelectionMode="Single">
+                       <ListBox.ItemsPanel>
+                           <ItemsPanelTemplate>
+                               <WrapPanel Orientation="Horizontal" />
+                           </ItemsPanelTemplate>
+                       </ListBox.ItemsPanel>
+                       <i:Interaction.Behaviors>
+                           <ia:EventTriggerBehavior EventName="SelectionChanged">
+                               <ia:InvokeCommandAction Command="{Binding VideoSectionsCommand}"
+                                                       CommandParameter="{Binding ElementName=NameVideoSections,Path=SelectedItem}" />
+                           </ia:EventTriggerBehavior>
+                           <ia:DataTriggerBehavior Binding="{Binding VideoSections.Count}" Value="0">
+                               <ia:ChangePropertyAction PropertyName="Height" Value="0" />
+                           </ia:DataTriggerBehavior>
+                           <ia:DataTriggerBehavior Binding="{Binding VideoSections.Count}" Value="1">
+                               <ia:ChangePropertyAction PropertyName="Height" Value="0" />
+                           </ia:DataTriggerBehavior>
+                           <ia:DataTriggerBehavior Binding="{Binding VideoSections.Count}"
+                                                   ComparisonCondition="GreaterThan" Value="1">
+                               <ia:ChangePropertyAction PropertyName="Height" Value="Nan" />
+                           </ia:DataTriggerBehavior>
+                       </i:Interaction.Behaviors>
+                   </ListBox>
+               </ScrollViewer>
+                
+                <GridSplitter Grid.Row="1" ResizeDirection="Rows"></GridSplitter>
                 <DataGrid
                     x:Name="NameVideoPages"
-                    Grid.Row="1"
+                    Grid.Row="2"
                     BorderThickness="1"
                     BorderBrush="Gray"
                     CanUserSortColumns="False"
@@ -426,7 +430,7 @@
                     </DataGrid.Columns>
                 </DataGrid>
 
-                <Grid Grid.Row="2" Margin="0,10,0,0" ColumnDefinitions="60,80,140,*,100,100">
+                <Grid Grid.Row="3" Margin="0,10,0,0" ColumnDefinitions="60,80,140,*,100,100">
                     <CheckBox
                         Grid.Column="0"
                         HorizontalAlignment="Left"

--- a/DownKyi/Views/ViewVideoDetail.axaml
+++ b/DownKyi/Views/ViewVideoDetail.axaml
@@ -6,6 +6,7 @@
              xmlns:i="using:Avalonia.Xaml.Interactivity"
              xmlns:ia="clr-namespace:Avalonia.Xaml.Interactions.Core;assembly=Avalonia.Xaml.Interactions"
              xmlns:custom="clr-namespace:DownKyi.CustomControl"
+             xmlns:behavior="clr-namespace:DownKyi.CustomAction"
              xmlns:iac="clr-namespace:Avalonia.Xaml.Interactions.Custom;assembly=Avalonia.Xaml.Interactions.Custom"
              x:DataType="vm:ViewVideoDetailViewModel">
     <Grid RowDefinitions="50,10,*">
@@ -252,12 +253,13 @@
                 </Grid>
             </DockPanel>
 
-            <Grid Grid.Row="1" Margin="10,10,10,10" RowDefinitions="200,4,*,40">
-               <ScrollViewer MinHeight="200">
+            <Grid Grid.Row="1" Margin="10,10,10,10" 
+                  RowDefinitions="Auto,5,*,40">
+               <ScrollViewer Grid.Row="0" 
+                             MaxHeight="220"
+                             VerticalScrollBarVisibility="Auto">
                    <ListBox
-                   
                        x:Name="NameVideoSections"
-                       Grid.Row="0"
                        ItemContainerTheme="{StaticResource TagItemStyle}"
                        ItemsSource="{Binding VideoSections, Mode=TwoWay}"
                        Theme="{StaticResource TagStyle}"
@@ -286,10 +288,16 @@
                    </ListBox>
                </ScrollViewer>
                 
-                <GridSplitter Grid.Row="1" ResizeDirection="Rows"></GridSplitter>
+                <GridSplitter Grid.Row="1"
+                              ShowsPreview="True"
+                              behavior:GridSplitterExtensions.ResetGridBehavior="{Binding ResetGridBehavior}"
+                              ResizeDirection="Rows">
+                   
+                </GridSplitter>
                 <DataGrid
                     x:Name="NameVideoPages"
                     Grid.Row="2"
+                    VerticalAlignment="Stretch"
                     BorderThickness="1"
                     BorderBrush="Gray"
                     CanUserSortColumns="False"
@@ -430,7 +438,8 @@
                     </DataGrid.Columns>
                 </DataGrid>
 
-                <Grid Grid.Row="3" Margin="0,10,0,0" ColumnDefinitions="60,80,140,*,100,100">
+                <Grid Grid.Row="3"
+                      Margin="0,10,0,0" ColumnDefinitions="60,80,140,*,100,100">
                     <CheckBox
                         Grid.Column="0"
                         HorizontalAlignment="Left"


### PR DESCRIPTION
来源：leiurayer/downkyi#1836。使用BV1Mb42177J7 解析合集过多，数据展示高度过低。所以加入合集滚动与网格分割器，以优化体验