### PR TITLE
feat: 新增动态分辨率处理，减少图片密集页面的内存占用

### DIFF
--- a/DownKyi/CustomControl/AsyncImageLoader/IAsyncImageLoader.cs
+++ b/DownKyi/CustomControl/AsyncImageLoader/IAsyncImageLoader.cs
@@ -10,6 +10,7 @@ public interface IAsyncImageLoader : IDisposable
     ///     Loads image
     /// </summary>
     /// <param name="url">Target url</param>
+    /// <param name="quality">quality</param>
     /// <returns>Bitmap</returns>
-    public Task<Bitmap?> ProvideImageAsync(string url);
+    public Task<Bitmap?> ProvideImageAsync(string url,int maxWidth, int maxHeight,int quality);
 }

--- a/DownKyi/CustomControl/AsyncImageLoader/ImageBrushLoader.cs
+++ b/DownKyi/CustomControl/AsyncImageLoader/ImageBrushLoader.cs
@@ -12,8 +12,16 @@ namespace DownKyi.CustomControl.AsyncImageLoader;
 public static class ImageBrushLoader
 {
     private static readonly ParametrizedLogger? Logger;
-    public static IAsyncImageLoader AsyncImageLoader { get; set; } = new DiskCachedWebImageLoader(Path.Combine(StorageManager.GetCache(), "Images"));
 
+    public static IAsyncImageLoader AsyncImageLoader { get; set; } =
+        new DiskCachedWebImageLoader(Path.Combine(StorageManager.GetCache(), "Images"));
+
+    
+    public static readonly AttachedProperty<int> MaxRenderWidthProperty =
+        AvaloniaProperty.RegisterAttached<ImageBrush, int>("MaxRenderWidth", typeof(ImageLoader), 200);
+
+    public static readonly AttachedProperty<int> MaxRenderHeightProperty =
+        AvaloniaProperty.RegisterAttached<ImageBrush, int>("MaxRenderHeight", typeof(ImageLoader), 200);
     static ImageBrushLoader()
     {
         SourceProperty.Changed.AddClassHandler<ImageBrush>(OnSourceChanged);
@@ -33,7 +41,8 @@ public static class ImageBrushLoader
         {
             if (newValue is not null)
             {
-                bitmap = await AsyncImageLoader.ProvideImageAsync(newValue);
+                bitmap = await AsyncImageLoader.ProvideImageAsync(newValue,GetMaxRenderWidth(imageBrush) ,
+                    GetMaxRenderHeight(imageBrush),GetQuality(imageBrush));
             }
         }
         catch (Exception e)
@@ -47,7 +56,21 @@ public static class ImageBrushLoader
         SetIsLoading(imageBrush, false);
     }
 
-    public static readonly AttachedProperty<string?> SourceProperty = AvaloniaProperty.RegisterAttached<ImageBrush, string?>("Source", typeof(ImageLoader));
+    public static readonly AttachedProperty<string?> SourceProperty =
+        AvaloniaProperty.RegisterAttached<ImageBrush, string?>("Source", typeof(ImageLoader));
+
+    public static readonly AttachedProperty<int> QualityProperty = AvaloniaProperty.RegisterAttached<ImageBrush, int>(
+        "Quality", typeof(ImageLoader), defaultValue: 65, 
+        coerce:(s, e) =>
+        {
+            if (e > 100 || e < 0)
+            {
+                return 65;
+            }
+            return e;
+        }
+    );
+
 
     public static string? GetSource(ImageBrush element)
     {
@@ -59,7 +82,38 @@ public static class ImageBrushLoader
         element.SetValue(SourceProperty, value);
     }
 
-    public static readonly AttachedProperty<bool> IsLoadingProperty = AvaloniaProperty.RegisterAttached<ImageBrush, bool>("IsLoading", typeof(ImageLoader));
+    public static int GetQuality(ImageBrush element)
+    {
+        return element.GetValue(QualityProperty);
+    }
+    
+    public static int GetMaxRenderHeight(ImageBrush element)
+    {
+        return element.GetValue(MaxRenderHeightProperty);
+    }
+    
+    public static int GetMaxRenderWidth(ImageBrush element)
+    {
+        return element.GetValue(MaxRenderWidthProperty);
+    }
+    
+    public static void SetMaxRenderHeight(ImageBrush element, int? value)
+    {
+        element.SetValue(MaxRenderHeightProperty, value);
+    }
+    
+    public static void SetMaxRenderWidth(ImageBrush element, int? value)
+    {
+        element.SetValue(MaxRenderWidthProperty, value);
+    }
+
+    public static void SetQuality(ImageBrush element, int? value)
+    {
+        element.SetValue(QualityProperty, value);
+    }
+
+    public static readonly AttachedProperty<bool> IsLoadingProperty =
+        AvaloniaProperty.RegisterAttached<ImageBrush, bool>("IsLoading", typeof(ImageLoader));
 
     public static bool GetIsLoading(ImageBrush element)
     {

--- a/DownKyi/CustomControl/AsyncImageLoader/ImageLoader.cs
+++ b/DownKyi/CustomControl/AsyncImageLoader/ImageLoader.cs
@@ -24,7 +24,24 @@ public static class ImageLoader
 
     public static readonly AttachedProperty<bool> IsLoadingProperty =
         AvaloniaProperty.RegisterAttached<Image, bool>("IsLoading", typeof(ImageLoader));
+    
+    public static readonly AttachedProperty<int> MaxRenderWidthProperty =
+        AvaloniaProperty.RegisterAttached<Image, int>("MaxRenderWidth", typeof(ImageLoader), 200);
 
+    public static readonly AttachedProperty<int> MaxRenderHeightProperty =
+        AvaloniaProperty.RegisterAttached<Image, int>("MaxRenderHeight", typeof(ImageLoader), 200);
+
+    public static readonly AttachedProperty<int> QualityProperty = AvaloniaProperty.RegisterAttached<Image, int>(
+        "Quality", typeof(ImageLoader), defaultValue: 65, 
+        coerce:(s, e) =>
+        {
+            if (e > 100 || e < 0)
+            {
+                return 65;
+            }
+            return e;
+        }
+    );
     static ImageLoader()
     {
         SourceProperty.Changed.AddClassHandler<Image>(OnSourceChanged);
@@ -54,7 +71,9 @@ public static class ImageLoader
         }
 
         SetIsLoading(sender, true);
-
+        var  quality = GetQuality(sender);
+        int width = (int)sender.Width;
+        int height = (int)sender.Height;
         var bitmap = await Task.Run(async () =>
         {
             try
@@ -63,7 +82,7 @@ public static class ImageLoader
                 // The Bitmap constructor is expensive and cannot be cancelled
                 await Task.Delay(10, cts.Token);
 
-                return await AsyncImageLoader.ProvideImageAsync(url);
+                return await AsyncImageLoader.ProvideImageAsync(url,width,height,quality);
             }
             catch (TaskCanceledException)
             {
@@ -94,11 +113,45 @@ public static class ImageLoader
     {
         element.SetValue(SourceProperty, value);
     }
+    
+    public static int GetQuality(Image element)
+    {
+        return element.GetValue(QualityProperty);
+    }
+    
+    public static int GetMaxRenderHeight(Image element)
+    {
+        return element.GetValue(MaxRenderHeightProperty);
+    }
+    
+    public static int GetMaxRenderWidth(Image element)
+    {
+        return element.GetValue(MaxRenderWidthProperty);
+    }
+    
+    public static void SetMaxRenderHeight(Image element, int? value)
+    {
+        element.SetValue(MaxRenderHeightProperty, value);
+    }
+    
+    public static void SetMaxRenderWidth(Image element, int? value)
+    {
+        element.SetValue(MaxRenderWidthProperty, value);
+    }
+    
+    
+
+    public static void SetQuality(Image element, int? value)
+    {
+        element.SetValue(QualityProperty, value);
+    }
 
     public static bool GetIsLoading(Image element)
     {
         return element.GetValue(IsLoadingProperty);
     }
+    
+    
 
     private static void SetIsLoading(Image element, bool value)
     {

--- a/DownKyi/CustomControl/AsyncImageLoader/Loaders/AdvancedImage.axaml.cs
+++ b/DownKyi/CustomControl/AsyncImageLoader/Loaders/AdvancedImage.axaml.cs
@@ -24,6 +24,18 @@ public class AdvancedImage : ContentControl
     public static readonly StyledProperty<string?> SourceProperty = AvaloniaProperty.Register<AdvancedImage, string?>(nameof(Source));
 
     /// <summary>
+    ///     Defines the <see cref="QualityProperty" /> property.
+    /// </summary>
+    public static readonly StyledProperty<int> QualityProperty = AvaloniaProperty.Register<AdvancedImage, int>(nameof(Source),defaultValue:25,coerce:
+        (s, e) =>
+        {
+            if (e > 100 || e < 0)
+            {
+                return 25;
+            }
+            return e;
+        });
+    /// <summary>
     ///     Defines the <see cref="ShouldLoaderChangeTriggerUpdate" /> property.
     /// </summary>
     public static readonly DirectProperty<AdvancedImage, bool> ShouldLoaderChangeTriggerUpdateProperty =
@@ -117,6 +129,16 @@ public class AdvancedImage : ContentControl
     {
         get => GetValue(SourceProperty);
         set => SetValue(SourceProperty, value);
+    }
+    
+    /// <summary>
+    ///   Gets or sets the quality of the image that will be displayed
+    /// </summary>
+    
+    public int Quality
+    {
+        get => GetValue(QualityProperty);
+        set => SetValue(QualityProperty, value);
     }
 
     /// <summary>
@@ -236,7 +258,7 @@ public class AdvancedImage : ContentControl
                 }
 
                 loader ??= ImageLoader.AsyncImageLoader;
-                return await loader.ProvideImageAsync(source);
+                return await loader.ProvideImageAsync(source,(int)Width,(int)Height,Quality);
             }
             catch (TaskCanceledException)
             {

--- a/DownKyi/CustomControl/AsyncImageLoader/Loaders/DiskCachedWebImageLoader.cs
+++ b/DownKyi/CustomControl/AsyncImageLoader/Loaders/DiskCachedWebImageLoader.cs
@@ -23,11 +23,10 @@ public class DiskCachedWebImageLoader : BaseWebImageLoader
     }
 
     /// <inheritdoc />
-    protected override Task<Bitmap?> LoadFromGlobalCache(string url)
+    protected override Task<byte[]> LoadFromGlobalCache(string url)
     {
         var path = Path.Combine(_cacheFolder, CreateMd5(url));
-
-        return File.Exists(path) ? Task.FromResult<Bitmap?>(new Bitmap(path)) : Task.FromResult<Bitmap?>(null);
+        return File.Exists(path) ? File.ReadAllBytesAsync(path) : Task.FromResult<byte[]>(Array.Empty<byte>());
     }
 
 #if NETSTANDARD2_1

--- a/DownKyi/CustomControl/AsyncImageLoader/Loaders/RamCachedWebImageLoader.cs
+++ b/DownKyi/CustomControl/AsyncImageLoader/Loaders/RamCachedWebImageLoader.cs
@@ -7,7 +7,7 @@ namespace DownKyi.CustomControl.AsyncImageLoader.Loaders;
 
 public class RamCachedWebImageLoader : BaseWebImageLoader
 {
-    private readonly ConcurrentDictionary<string, Task<Bitmap?>> _memoryCache = new();
+    private readonly ConcurrentDictionary<string, Task<byte[]?>> _memoryCache = new();
 
     /// <inheritdoc />
     public RamCachedWebImageLoader()
@@ -20,12 +20,12 @@ public class RamCachedWebImageLoader : BaseWebImageLoader
     }
 
     /// <inheritdoc />
-    public override async Task<Bitmap?> ProvideImageAsync(string url)
+    public override async Task<Bitmap?> ProvideImageAsync(string url, int maxWidth, int maxHeight,int quality)
     {
-        var bitmap = await _memoryCache.GetOrAdd(url, LoadAsync).ConfigureAwait(false);
+        var bytes = await _memoryCache.GetOrAdd(url, LoadBytesAsync).ConfigureAwait(false);
         // If load failed - remove from cache and return
         // Next load attempt will try to load image again
-        if (bitmap == null) _memoryCache.TryRemove(url, out _);
-        return bitmap;
+        if (bytes == null) _memoryCache.TryRemove(url, out _);
+        return ConvertToLowResolution(bytes,maxWidth,maxHeight,quality);
     }
 }

--- a/DownKyi/Views/ViewPublicFavorites.axaml
+++ b/DownKyi/Views/ViewPublicFavorites.axaml
@@ -65,7 +65,7 @@
                 Grid.Column="0"
                 Margin="10,10,10,10"
                 Orientation="Vertical">
-                <Image asyncImageLoader:ImageLoader.Source="{Binding Favorites.CoverUrl}">
+                <Image asyncImageLoader:ImageLoader.Source="{Binding Favorites.CoverUrl}" >
                     <Image.ContextMenu>
                         <ContextMenu>
                             <MenuItem Command="{Binding CopyCoverCommand}" Header="{DynamicResource CopyCover}" />


### PR DESCRIPTION
针对 f744d26 做出的修改。直接展示图片原始分辨率图像 遇到在收藏等页面，内存占用会达到1g以上