### PR TITLE
fix: 修复收藏夹页面返回概率会出现的崩溃

### DIFF
--- a/DownKyi/ViewModels/ViewMyFavoritesViewModel.cs
+++ b/DownKyi/ViewModels/ViewMyFavoritesViewModel.cs
@@ -220,10 +220,9 @@ public class ViewMyFavoritesViewModel : ViewModelBase
         InitView();
 
         ArrowBack.Fill = DictionaryResource.GetColor("ColorText");
-
         // 结束任务
-        _tokenSource1.Cancel();
-        _tokenSource2.Cancel();
+        _tokenSource1?.Cancel();
+        _tokenSource2?.Cancel();
 
         var parameter = new NavigationParam
         {


### PR DESCRIPTION
如果其它功能界面发起的api请求未被完成，之后在进入到收藏页再返回会很大概率崩溃