### PR TITLE
feat: 新增自动定位并选中视频的功能

### DIFF
--- a/DownKyi/CustomAction/ScrollIntoViewBehavior.cs
+++ b/DownKyi/CustomAction/ScrollIntoViewBehavior.cs
@@ -1,0 +1,41 @@
+using Avalonia.Controls;
+using Avalonia.Xaml.Interactivity;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DownKyi.CustomAction;
+
+public class ScrollIntoViewBehavior : Behavior<DataGrid>
+{
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        AssociatedObject.SelectionChanged += OnSelectionChanged;
+    }
+
+    protected override void OnDetaching()
+    {
+        base.OnDetaching();
+        AssociatedObject.SelectionChanged -= OnSelectionChanged;
+    }
+
+    private async void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (AssociatedObject.SelectedItem == null)
+        {
+            return;
+        }
+
+        // 等待UI更新完成
+        await Task.Delay(100);
+
+        // 使用UI线程异步执行滚动操作
+        await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            // 直接使用DataGrid的ScrollIntoView方法滚动到选中项
+            AssociatedObject.ScrollIntoView(AssociatedObject.SelectedItem, null);
+        });
+    }
+}

--- a/DownKyi/ViewModels/ViewVideoDetailViewModel.cs
+++ b/DownKyi/ViewModels/ViewVideoDetailViewModel.cs
@@ -713,6 +713,9 @@ public class ViewVideoDetailViewModel : ViewModelBase
                     IsSelected = true,
                     VideoPages = pages
                 });
+
+                // 自动定位到合集中对应的视频位置
+                AutoLocateAndSelectVideoPosition();
             });
         }
         else
@@ -724,6 +727,9 @@ public class ViewVideoDetailViewModel : ViewModelBase
             {
                 VideoSections.AddRange(videoSections);
                 CaCheVideoSections.AddRange(videoSectionsData);
+
+                // 自动定位到合集中对应的视频位置
+                AutoLocateAndSelectVideoPosition();
             });
         }
     }
@@ -736,6 +742,45 @@ public class ViewVideoDetailViewModel : ViewModelBase
     private void ParseVideo(IInfoService videoInfoService, VideoPage videoPage)
     {
         videoInfoService.GetVideoStream(videoPage);
+    }
+
+    /// <summary>
+    /// 自动定位到合集中对应的视频位置
+    /// </summary>
+    private VideoPage selectedVideoPage;
+    public VideoPage SelectedVideoPage
+    {
+        get => selectedVideoPage;
+        set => SetProperty(ref selectedVideoPage, value);
+    }
+
+    private void AutoLocateAndSelectVideoPosition()
+    {
+        
+        long avid = ParseEntrance.GetAvId(_input);
+        string bvid = ParseEntrance.GetBvId(_input);
+
+        // 确保在UI线程上更新属性
+        App.PropertyChangeAsync(() =>
+        {
+            // 遍历所有视频页面，找到对应的位置
+            foreach (var section in VideoSections)
+            {
+                section.IsSelected = true;
+                foreach (var page in section.VideoPages)
+                {
+                    
+                    if (page.Avid == avid || page.Bvid == bvid)
+                    {
+                        // 选中对应的视频页面
+                        page.IsSelected = true;
+                        // 设置SelectedVideoPage以触发DataGrid的SelectedItem变化和滚动操作
+                        SelectedVideoPage = page;
+                        return;
+                    }
+                }
+            }
+        });
     }
 
     /// <summary>

--- a/DownKyi/Views/ViewVideoDetail.axaml
+++ b/DownKyi/Views/ViewVideoDetail.axaml
@@ -301,7 +301,8 @@
                     CanUserResizeColumns="True"
                     IsReadOnly="True"
                     ItemsSource="{ReflectionBinding ElementName=NameVideoSections, Path=SelectedItem.VideoPages, Mode=TwoWay}"
-                    SelectionMode="Extended">
+                    SelectionMode="Extended"
+                    SelectedItem="{Binding SelectedVideoPage, Mode=TwoWay}">
                     <DataGrid.ColumnHeaderTheme>
                         <ControlTheme TargetType="{x:Type DataGridColumnHeader}">
                             <Setter Property="HorizontalContentAlignment" Value="Center" />
@@ -390,6 +391,7 @@
                             <InvokeCommandAction Command="{Binding VideoPagesCommand}"
                                                  CommandParameter="{Binding ElementName=NameVideoPages, Path=SelectedItems}" />
                         </EventTriggerBehavior>
+                        <behavior:ScrollIntoViewBehavior />
                     </Interaction.Behaviors>
                     <DataGrid.Columns>
                         <DataGridTextColumn


### PR DESCRIPTION
基于 #402 ,新增自动定位并选中视频的功能

## 功能概述

实现了在视频详情页中，当用户输入包含特定avid或bvid的链接时，系统能够自动定位并选中对应的视频页面，同时滚动到可视区域。

## 实现细节

1. **创建了滚动行为类**：
   - `ScrollIntoViewBehavior.cs`：继承自Avalonia的Behavior，实现了DataGrid选中项自动滚动到可视区域的功能
   - 监听SelectionChanged事件，使用异步方式确保UI更新完成后再执行滚动操作

2. **添加了自动定位逻辑**：
   - 在`ViewVideoDetailViewModel.cs`中实现了`AutoLocateAndSelectVideoPosition()`方法
   - 该方法从输入字符串中解析出avid和bvid
   - 遍历所有视频页面，找到匹配的视频并设置为选中状态
   - 通过设置`SelectedVideoPage`属性触发DataGrid的SelectedItem变化

3. **应用了行为到视图**：
   - 在`ViewVideoDetail.axaml`中添加了`<behavior:ScrollIntoViewBehavior />`
   - 确保DataGrid在选中项变化时自动滚动

## 影响范围

- 新增文件：`DownKyi/CustomAction/ScrollIntoViewBehavior.cs`
- 修改文件：
  - `DownKyi/ViewModels/ViewVideoDetailViewModel.cs`
  - `DownKyi/Views/ViewVideoDetail.axaml`